### PR TITLE
Seg Fault fix for webkit_web_resource_get_data()

### DIFF
--- a/ext/Module/Install/PRIVATE/WebKit.pm
+++ b/ext/Module/Install/PRIVATE/WebKit.pm
@@ -34,8 +34,19 @@ sub webkit {
 
     our @xs_files = <xs/*.xs>;
 
-    our $webkit = ExtUtils::Depends->new('Gtk2::WebKit', 'Gtk2', 'Gtk2::Soup');
-    $webkit->set_inc($pkgconfig{cflags} . ($Module::Install::AUTHOR ? ' -Wall -Werror' : ''));
+    my @extra_dependencies = 'Gtk2';
+    my $extra_cflags = "";
+    eval {
+        require Glib::Soup;
+        push @extra_dependencies, 'Glib::Soup';
+        $extra_cflags = " -DGLIB_SOUP_PERL";
+        1;
+    } or do {
+        my $error = $@;
+    };
+
+    our $webkit = ExtUtils::Depends->new('Gtk2::WebKit', 'Gtk2', @extra_dependencies);
+    $webkit->set_inc($pkgconfig{cflags} . ($Module::Install::AUTHOR ? ' -Wall -Werror' : '') . $extra_cflags);
     $webkit->set_libs($pkgconfig{libs});
     $webkit->add_xs(@xs_files);
     $webkit->add_pm('lib/Gtk2/WebKit.pm', '$(INST_LIBDIR)/WebKit.pm');

--- a/ext/Module/Install/PRIVATE/WebKit.pm
+++ b/ext/Module/Install/PRIVATE/WebKit.pm
@@ -34,7 +34,7 @@ sub webkit {
 
     our @xs_files = <xs/*.xs>;
 
-    our $webkit = ExtUtils::Depends->new('Gtk2::WebKit', 'Gtk2');
+    our $webkit = ExtUtils::Depends->new('Gtk2::WebKit', 'Gtk2', 'Gtk2::Soup');
     $webkit->set_inc($pkgconfig{cflags} . ($Module::Install::AUTHOR ? ' -Wall -Werror' : ''));
     $webkit->set_libs($pkgconfig{libs});
     $webkit->add_xs(@xs_files);

--- a/lib/Gtk2/WebKit.pm
+++ b/lib/Gtk2/WebKit.pm
@@ -3,6 +3,7 @@ package Gtk2::WebKit;
 use strict;
 use warnings;
 use Gtk2;
+use Gtk2::Soup;
 use base qw/DynaLoader/;
 
 our $VERSION = '0.09';

--- a/lib/Gtk2/WebKit.pm
+++ b/lib/Gtk2/WebKit.pm
@@ -3,7 +3,6 @@ package Gtk2::WebKit;
 use strict;
 use warnings;
 use Gtk2;
-use Gtk2::Soup;
 use base qw/DynaLoader/;
 
 our $VERSION = '0.09';
@@ -11,6 +10,12 @@ our $VERSION = '0.09';
 sub dl_load_flags { 0x01 }
 
 __PACKAGE__->bootstrap($VERSION);
+
+if (__PACKAGE__->HAS_GLIB_SOUP) {
+	require Glib::Soup;
+	Glib::Soup->import();
+}
+
 
 =head1 NAME
 

--- a/perl_webkit.h
+++ b/perl_webkit.h
@@ -1,3 +1,4 @@
 #include <gtk2perl.h>
+#include <soup-perl.h>
 #include <webkit/webkit.h>
 #include "webkit-autogen.h"

--- a/perl_webkit.h
+++ b/perl_webkit.h
@@ -1,4 +1,6 @@
 #include <gtk2perl.h>
+#ifdef GLIB_SOUP_PERL
 #include <soup-perl.h>
+#endif
 #include <webkit/webkit.h>
 #include "webkit-autogen.h"

--- a/t/session.t
+++ b/t/session.t
@@ -5,7 +5,14 @@ use Test::More;
 use Gtk2 -init;
 use Gtk2::WebKit;
 
-my $session = Gtk2::WebKit->get_default_session;
-isa_ok($session, 'Gtk2::SoupSession');
+if (Gtk2::WebKit->can("get_default_session")) {
+	my $session = Gtk2::WebKit->get_default_session;
+	isa_ok($session, 'Glib::SoupSession');
+}
+else {
+	SKIP: {
+		skip "Can't find get_default_session", 1;
+	}
+}
 
 done_testing;

--- a/t/session.t
+++ b/t/session.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Gtk2 -init;
+use Gtk2::WebKit;
+
+my $session = Gtk2::WebKit->get_default_session;
+isa_ok($session, 'Gtk2::SoupSession');
+
+done_testing;

--- a/xs/WebKit.xs
+++ b/xs/WebKit.xs
@@ -27,9 +27,20 @@ webkit_check_version (class, major, minor, micro)
 		RETVAL
 
 
+#ifdef GLIB_SOUP_PERL
+
+int
+HAS_GLIB_SOUP (class)
+	CODE:
+		RETVAL = 1;
+	OUTPUT:
+		RETVAL
+
 SoupSession *
 webkit_get_default_session (class)
 	C_ARGS:
+
+#endif
 
 
 BOOT:

--- a/xs/WebKit.xs
+++ b/xs/WebKit.xs
@@ -26,6 +26,17 @@ webkit_check_version (class, major, minor, micro)
 	OUTPUT:
 		RETVAL
 
+
+#SoupSession *
+GObject *
+webkit_get_default_session (class)
+	CODE:
+		RETVAL = (GObject *) webkit_get_default_session();
+
+	OUTPUT:
+		RETVAL
+
+
 BOOT:
 #include "register.xsh"
 #include "boot.xsh"

--- a/xs/WebKit.xs
+++ b/xs/WebKit.xs
@@ -27,14 +27,9 @@ webkit_check_version (class, major, minor, micro)
 		RETVAL
 
 
-#SoupSession *
-GObject *
+SoupSession *
 webkit_get_default_session (class)
-	CODE:
-		RETVAL = (GObject *) webkit_get_default_session();
-
-	OUTPUT:
-		RETVAL
+	C_ARGS:
 
 
 BOOT:

--- a/xs/WebKitWebResource.xs
+++ b/xs/WebKitWebResource.xs
@@ -26,7 +26,12 @@ webkit_web_resource_get_data (web_resource)
 		GString *data;
 	CODE:
 		data = webkit_web_resource_get_data (web_resource);
-		RETVAL = newSVpvn (data->str, data->len);
+		if (data == NULL) {
+			RETVAL = &PL_sv_undef;
+		}
+		else {
+			RETVAL = newSVpvn (data->str, data->len);
+		}
 	OUTPUT:
 		RETVAL
 

--- a/xs/WebKitWebView.xs
+++ b/xs/WebKitWebView.xs
@@ -311,15 +311,6 @@ webkit_web_view_set_full_content_zoom (web_view, full_content_zoom)
 		WebKitWebView *web_view
 		gboolean full_content_zoom
 
-#SoupSession *
-GObject *
-webkit_get_default_session (class)
-	CODE:
-		RETVAL = (GObject *) webkit_get_default_session();
-
-	OUTPUT:
-		RETVAL
-
 const gchar *
 webkit_web_view_get_encoding (web_view)
 		WebKitWebView *web_view

--- a/xs/WebKitWebView.xs
+++ b/xs/WebKitWebView.xs
@@ -312,8 +312,13 @@ webkit_web_view_set_full_content_zoom (web_view, full_content_zoom)
 		gboolean full_content_zoom
 
 #SoupSession *
-#webkit_get_default_session (class)
-#	C_ARGS:
+GObject *
+webkit_get_default_session (class)
+	CODE:
+		RETVAL = (GObject *) webkit_get_default_session();
+
+	OUTPUT:
+		RETVAL
 
 const gchar *
 webkit_web_view_get_encoding (web_view)


### PR DESCRIPTION
It seems that webkit_web_resource_get_data() can return NULL if the
resource fails to load (ex: a site that has no favicon.ico).

Thanks for the 0.09 release!
